### PR TITLE
Add label to toggle

### DIFF
--- a/src/Formlet/Ocelot/Toggle.purs
+++ b/src/Formlet/Ocelot/Toggle.purs
@@ -7,10 +7,23 @@ import CitizenNet.Prelude
 
 import Formlet as Formlet
 import Formlet.Render as Formlet.Render
+import Option as Option
+
+type Params =
+  ( label :: Maybe String
+  )
+
+type ParamsOptional =
+  ( label :: String
+  )
+
+type ParamsRequired :: forall k. Row k
+type ParamsRequired = ()
 
 newtype Render action =
   Render
-    { onChange :: Boolean -> action
+    { label :: Maybe String
+    , onChange :: Boolean -> action
     , readonly :: Boolean
     , value :: Boolean
     }
@@ -19,16 +32,24 @@ derive instance newtypeToggle :: Newtype (Render action) _
 derive instance functorToggle :: Functor Render
 
 toggle ::
-  forall config options renders m.
+  forall config options polyParams renders m.
   Applicative m =>
+  Option.FromRecord polyParams ParamsRequired ParamsOptional =>
+  Option.ToRecord ParamsRequired ParamsOptional Params =>
+  Record polyParams ->
   Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (toggle :: Render | renders)) m Boolean Boolean
-toggle =
+toggle polyParams =
   Formlet.form_ \{ readonly } value ->
     Formlet.Render.inj
       { toggle:
           Render
-            { onChange: if readonly then const (pure identity) else pure <<< const
+            { label: params.label
+            , onChange: if readonly then const (pure identity) else pure <<< const
             , readonly
             , value
             }
       }
+  where
+  params :: Record Params
+  params =
+    Option.recordToRecord (optionRecord polyParams :: OptionRecord ParamsRequired ParamsOptional)

--- a/src/Formlet/Ocelot/Toggle/Halogen.purs
+++ b/src/Formlet/Ocelot/Toggle/Halogen.purs
@@ -19,26 +19,23 @@ render ::
   Formlet.Ocelot.Toggle.Render action ->
   Array (Halogen.ComponentHTML action slots m)
 render { key } { readonly } (Formlet.Ocelot.Toggle.Render render') = case render'.label of
-  Nothing -> toggle
+  Nothing -> [ toggle ]
   Just label ->
     [ Halogen.HTML.div
         [ Ocelot.HTML.Properties.css "flex items-center" ]
-        ( toggle
-            <>
-              [ Halogen.HTML.span
-                  [ Ocelot.HTML.Properties.css "mb-2" ]
-                  [ Halogen.HTML.text label ]
-              ]
-        )
-    ]
-  where
-  toggle :: Array (Halogen.ComponentHTML action slots m)
-  toggle =
-    [ Ocelot.Block.Toggle.toggle
-        [ Halogen.HTML.Properties.checked render'.value
-        , Halogen.HTML.Properties.disabled (readonly || render'.readonly)
-        , Halogen.HTML.Events.onChecked render'.onChange
-        , Halogen.HTML.Properties.id key
-        , Halogen.HTML.Properties.name key
+        [ toggle
+        , Halogen.HTML.span
+            [ Ocelot.HTML.Properties.css "mb-2" ]
+            [ Halogen.HTML.text label ]
         ]
     ]
+  where
+  toggle :: Halogen.ComponentHTML action slots m
+  toggle =
+    Ocelot.Block.Toggle.toggle
+      [ Halogen.HTML.Properties.checked render'.value
+      , Halogen.HTML.Properties.disabled (readonly || render'.readonly)
+      , Halogen.HTML.Events.onChecked render'.onChange
+      , Halogen.HTML.Properties.id key
+      , Halogen.HTML.Properties.name key
+      ]

--- a/src/Formlet/Ocelot/Toggle/Halogen.purs
+++ b/src/Formlet/Ocelot/Toggle/Halogen.purs
@@ -6,9 +6,11 @@ import CitizenNet.Prelude
 
 import Formlet.Ocelot.Toggle as Formlet.Ocelot.Toggle
 import Halogen as Halogen
+import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Events as Halogen.HTML.Events
 import Halogen.HTML.Properties as Halogen.HTML.Properties
 import Ocelot.Block.Toggle as Ocelot.Block.Toggle
+import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 
 render ::
   forall slots m config action.
@@ -16,12 +18,27 @@ render ::
   { readonly :: Boolean | config } ->
   Formlet.Ocelot.Toggle.Render action ->
   Array (Halogen.ComponentHTML action slots m)
-render { key } { readonly } (Formlet.Ocelot.Toggle.Render render') =
-  [ Ocelot.Block.Toggle.toggle
-      [ Halogen.HTML.Properties.checked render'.value
-      , Halogen.HTML.Properties.disabled (readonly || render'.readonly)
-      , Halogen.HTML.Events.onChecked render'.onChange
-      , Halogen.HTML.Properties.id key
-      , Halogen.HTML.Properties.name key
-      ]
-  ]
+render { key } { readonly } (Formlet.Ocelot.Toggle.Render render') = case render'.label of
+  Nothing -> toggle
+  Just label ->
+    [ Halogen.HTML.div
+        [ Ocelot.HTML.Properties.css "flex items-center" ]
+        ( toggle
+            <>
+              [ Halogen.HTML.span
+                  [ Ocelot.HTML.Properties.css "mb-2" ]
+                  [ Halogen.HTML.text label ]
+              ]
+        )
+    ]
+  where
+  toggle :: Array (Halogen.ComponentHTML action slots m)
+  toggle =
+    [ Ocelot.Block.Toggle.toggle
+        [ Halogen.HTML.Properties.checked render'.value
+        , Halogen.HTML.Properties.disabled (readonly || render'.readonly)
+        , Halogen.HTML.Events.onChecked render'.onChange
+        , Halogen.HTML.Properties.id key
+        , Halogen.HTML.Properties.name key
+        ]
+    ]

--- a/test/Test/Formlet/Ocelot/Toggle.purs
+++ b/test/Test/Formlet/Ocelot/Toggle.purs
@@ -21,7 +21,7 @@ suite =
           rendered :: Formlet.Ocelot.Toggle.Render (Boolean -> Boolean)
           rendered =
             Formlet.Render.match { toggle: map (un Data.Identity.Identity) }
-              $ Formlet.render Formlet.Ocelot.Toggle.toggle { readonly }
+              $ Formlet.render (Formlet.Ocelot.Toggle.toggle {}) { readonly }
               $ value
 
           expected :: Boolean


### PR DESCRIPTION
It's sometimes useful to include the semantics of a toggle state in text next to the control.

We add a configuration argument to `Formlet.Ocelot.Toggle.toggle` with an optional `label` field. If that field is set, the specified text is rendered to the right of the toggle.