### PR TITLE
API-3207 Support `interval` Bound in `Formlet.Ocelot.DateTime`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What does this pull request do?
+
+Please describe the purpose of the pull request, including any background context and links to related issues. If this introduces a large change to the project, please describe what you have implemented.
+
+## Where should the reviewer start?
+
+Help save the reviewer time by highlighting the most important sections of code.
+
+## How should this be manually tested?
+
+If this is a new feature, you should provide new test coverage. If it fixes an existing bug, you should provide a failing test case this change fixes. Other than automated testing, what manual tests can the reviewer perform to verify your work?
+
+## Other Notes:
+
+Does the project documentation need to be updated? Should we introduce a new example, or update any existing examples? Does this PR require any other follow-up tasks?

--- a/src/Formlet/Ocelot/DateTime.purs
+++ b/src/Formlet/Ocelot/DateTime.purs
@@ -18,12 +18,10 @@ type Interval =
 
 type Params =
   ( interval :: Maybe Interval
-  , placeholder :: Maybe String
   )
 
 type ParamsOptional =
   ( interval :: Interval
-  , placeholder :: String
   )
 
 type ParamsRequired =
@@ -33,7 +31,6 @@ newtype Render action =
   Render
     { interval :: Maybe Interval
     , onChange :: Maybe DateTime -> action
-    , placeholder :: String
     , readonly :: Boolean
     , timezone :: TimeZone.TimeZone
     , value :: Maybe DateTime
@@ -64,7 +61,6 @@ dateTime polyParams =
           Render
             { interval: params.interval
             , onChange: if readonly then const (pure identity) else pure <<< const
-            , placeholder: fromMaybe "" params.placeholder
             , readonly
             , timezone
             , value

--- a/src/Formlet/Ocelot/DateTime.purs
+++ b/src/Formlet/Ocelot/DateTime.purs
@@ -1,5 +1,6 @@
 module Formlet.Ocelot.DateTime
-  ( Render(..)
+  ( Interval
+  , Render(..)
   , dateTime
   ) where
 
@@ -7,11 +8,31 @@ import CitizenNet.Prelude
 
 import Formlet as Formlet
 import Formlet.Render as Formlet.Render
+import Option as Option
 import TimeZone as TimeZone
+
+type Interval =
+  { end :: Maybe DateTime
+  , start :: Maybe DateTime
+  }
+
+type Params =
+  ( interval :: Maybe Interval
+  , placeholder :: Maybe String
+  )
+
+type ParamsOptional =
+  ( interval :: Interval
+  , placeholder :: String
+  )
+
+type ParamsRequired =
+  () :: Row Type
 
 newtype Render action =
   Render
-    { onChange :: Maybe DateTime -> action
+    { interval :: Maybe Interval
+    , onChange :: Maybe DateTime -> action
     , placeholder :: String
     , readonly :: Boolean
     , timezone :: TimeZone.TimeZone
@@ -22,9 +43,11 @@ derive instance newtypeDateTime :: Newtype (Render action) _
 derive instance functorDateTime :: Functor Render
 
 dateTime ::
-  forall config options renders m.
+  forall config options polyParams renders m.
   Applicative m =>
-  { placeholder :: String } ->
+  Option.FromRecord polyParams ParamsRequired ParamsOptional =>
+  Option.ToRecord ParamsRequired ParamsOptional Params =>
+  Record polyParams ->
   Formlet.Form
     { readonly :: Boolean
     , timezone :: TimeZone.TimeZone
@@ -34,15 +57,23 @@ dateTime ::
     m
     (Maybe DateTime)
     (Maybe DateTime)
-dateTime { placeholder } =
-  Formlet.form_ \{ readonly, timezone } value ->
+dateTime polyParams =
+  Formlet.form_ \({ readonly, timezone }) value ->
     Formlet.Render.inj
       { dateTime:
           Render
-            { onChange: if readonly then const (pure identity) else pure <<< const
-            , placeholder
+            { interval: params.interval
+            , onChange: if readonly then const (pure identity) else pure <<< const
+            , placeholder: fromMaybe "" params.placeholder
             , readonly
             , timezone
             , value
             }
       }
+  where
+  params :: Record Params
+  params =
+    Option.recordToRecord
+      ( optionRecord polyParams ::
+          OptionRecord ParamsRequired ParamsOptional
+      )

--- a/src/Formlet/Ocelot/DateTime/Halogen.purs
+++ b/src/Formlet/Ocelot/DateTime/Halogen.purs
@@ -31,6 +31,7 @@ render { readonly } (Formlet.Ocelot.DateTime.Render render') =
       unit
       component
       { disabled: readonly || render'.readonly
+      , interval: render'.interval
       , selection: render'.value
       , targetDate: Nothing
       , timezone: render'.timezone
@@ -53,6 +54,7 @@ type ChildSlots =
 
 type Input =
   { disabled :: Boolean
+  , interval :: Maybe Ocelot.DateTimePicker.Interval
   , selection :: Maybe DateTime
   , targetDate :: Maybe (Data.DateTime.Year /\ Data.DateTime.Month)
   , timezone :: TimeZone.TimeZone
@@ -114,7 +116,7 @@ component =
           unit
           Ocelot.DateTimePicker.component
           { disabled: state.disabled
-          , interval: Nothing -- NOTE(wenbo): use this to enforce end time before start time, and to remove dates in the past
+          , interval: state.interval
           , selection: toLocalDateTime state.timezone state.selection
           , targetDate: state.targetDate
           }

--- a/src/Formlet/Ocelot/DateTime/Halogen.purs
+++ b/src/Formlet/Ocelot/DateTime/Halogen.purs
@@ -116,7 +116,12 @@ component =
           unit
           Ocelot.DateTimePicker.component
           { disabled: state.disabled
-          , interval: state.interval
+          , interval: do
+              interval <- state.interval
+              pure
+                { end: toLocalDateTime state.timezone interval.end
+                , start: toLocalDateTime state.timezone interval.start
+                }
           , selection: toLocalDateTime state.timezone state.selection
           , targetDate: state.targetDate
           }

--- a/test/Test/Formlet/Ocelot/DateTime.purs
+++ b/test/Test/Formlet/Ocelot/DateTime.purs
@@ -27,7 +27,7 @@ suite =
           rendered :: Formlet.Ocelot.DateTime.Render (Maybe DateTime -> Maybe DateTime)
           rendered =
             Formlet.Render.match { dateTime: map (un Data.Identity.Identity) }
-              $ Formlet.render (Formlet.Ocelot.DateTime.dateTime { placeholder: "" })
+              $ Formlet.render (Formlet.Ocelot.DateTime.dateTime {})
                   { readonly
                   , timezone: TimeZone.utc
                   }


### PR DESCRIPTION
## What does this pull request do?

Add `Formlet.Ocelot.DateTime.Params` and expose `interval` bound from `Ocelot.DateTimePicker.Input` to restrict acceptable inputs.

## How should this be manually tested?

Tested in Wildcat
