### PR TITLE
API-3292 Add option for horizontal rendering to Formlet.Ocelot.Checkbox.checkboxSet

### DIFF
--- a/src/Formlet/Ocelot/Checkbox.purs
+++ b/src/Formlet/Ocelot/Checkbox.purs
@@ -1,32 +1,23 @@
 module Formlet.Ocelot.Checkbox
   ( Render(..)
   , checkbox
-  , checkboxSet
   , checkboxes
-  , enumCheckboxSet
-  , genericCheckboxSet
   ) where
 
 import CitizenNet.Prelude
 
-import Data.Set as Data.Set
 import Formlet as Formlet
-import Formlet.Ocelot.Enum as Formlet.Ocelot.Enum
 import Formlet.Render as Formlet.Render
-import Option as Option
-import Record as Record
 
 newtype Render a =
   Render
-    { columns :: Array Int -- NOTE positive integer (> 0), we use Array for its Semigroup instance and to collect column values
-    , options ::
-        Array
-          { checked :: Boolean
-          , label :: String
-          , onChange :: Boolean -> a
-          , readonly :: Boolean
-          }
-    }
+    ( Array
+        { checked :: Boolean
+        , label :: String
+        , onChange :: Boolean -> a
+        , readonly :: Boolean
+        }
+    )
 
 derive instance Newtype (Render a) _
 derive instance Functor Render
@@ -34,34 +25,6 @@ derive instance Functor Render
 derive newtype instance Semigroup (Render a)
 
 derive newtype instance Monoid (Render a)
-
-type SetParams a =
-  ( columns :: Maybe Int
-  , display :: a -> String
-  , options :: Array a
-  )
-
-type SetParamsEnum a =
-  ( columns :: Maybe Int
-  , display :: a -> String
-  )
-
-type SetParamsOptional =
-  ( columns :: Int
-  )
-
-type SetParamsOptionalEnum =
-  ( columns :: Int
-  )
-
-type SetParamsRequired a =
-  ( display :: a -> String
-  , options :: Array a
-  )
-
-type SetParamsRequiredEnum a =
-  ( display :: a -> String
-  )
 
 -- | A singleton checkbox Form that has `Boolean` as its input and output types.
 -- | Its render functor is also a `Monoid`, so it can be used in ado-notation.
@@ -95,65 +58,12 @@ checkbox ::
 checkbox label =
   Formlet.form_ \{ readonly } checked ->
     Render
-      { columns: []
-      , options:
-          [ { checked
-            , label
-            , onChange: if readonly then const (pure identity) else pure <<< const
-            , readonly
-            }
-          ]
-      }
-
--- | A Form that is a set of checkboxes based on the given list of options,
--- | each with its label and value. The result of a `checkboxSet` Form is the
--- | `Set` of all selected options.
-checkboxSet ::
-  forall config options polyParams renders m a.
-  Applicative m =>
-  Ord a =>
-  Option.FromRecord polyParams (SetParamsRequired a) SetParamsOptional =>
-  Option.ToRecord (SetParamsRequired a) SetParamsOptional (SetParams a) =>
-  Record polyParams ->
-  Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (checkbox :: Render | renders)) m (Set a) (Set a)
-checkboxSet polyParams =
-  Formlet.form \{ readonly } ->
-    { render:
-        \value ->
-          Formlet.Render.inj
-            { checkbox:
-                Render
-                  { columns: fromMaybe [] (pure <$> params.columns)
-                  , options:
-                      params.options
-                        # map \a ->
-                            let
-                              onChange :: Boolean -> m (Set a -> Set a)
-                              onChange =
-                                if _ then
-                                  pure (Data.Set.insert a)
-                                else
-                                  pure (Data.Set.delete a)
-                            in
-                              { checked: Data.Set.member a value
-                              , label: params.display a
-                              , onChange: if readonly then const (pure identity) else onChange
-                              , readonly
-                              }
-                  }
-            }
-    , validate: Right <<< validate
-    }
-  where
-  params :: Record (SetParams a)
-  params =
-    Option.recordToRecord
-      ( optionRecord polyParams ::
-          OptionRecord (SetParamsRequired a) SetParamsOptional
-      )
-
-  validate :: Set a -> Set a
-  validate = Data.Set.intersection (Data.Set.fromFoldable params.options)
+      [ { checked
+        , label
+        , onChange: if readonly then const (pure identity) else pure <<< const
+        , readonly
+        }
+      ]
 
 -- | Inject a combination of `checkbox` Forms inside a larger Form structure.
 checkboxes ::
@@ -162,46 +72,3 @@ checkboxes ::
   Formlet.Form { readonly :: Boolean | config } Render m value result ->
   Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (checkbox :: Render | renders)) m value result
 checkboxes = Formlet.mapRender (Formlet.Render.inj <<< { checkbox: _ })
-
--- | A `checkboxSet` Form where all option values are filled in based on the
--- | `Bounded` `Enum` instances for the value type.
-enumCheckboxSet ::
-  forall config options polyParams renders m a.
-  Applicative m =>
-  Ord a =>
-  Bounded a =>
-  Enum a =>
-  Option.FromRecord polyParams (SetParamsRequiredEnum a) SetParamsOptionalEnum =>
-  Option.ToRecord (SetParamsRequiredEnum a) SetParamsOptionalEnum (SetParamsEnum a) =>
-  Record polyParams ->
-  Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (checkbox :: Render | renders)) m (Set a) (Set a)
-enumCheckboxSet = checkboxSet <<< addOptions Formlet.Ocelot.Enum.enumOptions
-
--- | A `checkboxSet` Form where all option values are filled in with the
--- | constructors of a `Generic` enum sum type.
-genericCheckboxSet ::
-  forall config options polyParams renders m a rep.
-  Applicative m =>
-  Ord a =>
-  Generic a rep =>
-  Formlet.Ocelot.Enum.GenericEnumOptions a rep =>
-  Option.FromRecord polyParams (SetParamsRequiredEnum a) SetParamsOptionalEnum =>
-  Option.ToRecord (SetParamsRequiredEnum a) SetParamsOptionalEnum (SetParamsEnum a) =>
-  Record polyParams ->
-  Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (checkbox :: Render | renders)) m (Set a) (Set a)
-genericCheckboxSet = checkboxSet <<< addOptions Formlet.Ocelot.Enum.genericEnumOptions
-
-addOptions ::
-  forall a polyParams.
-  Option.FromRecord polyParams (SetParamsRequiredEnum a) SetParamsOptionalEnum =>
-  Option.ToRecord (SetParamsRequiredEnum a) SetParamsOptionalEnum (SetParamsEnum a) =>
-  Array a ->
-  Record polyParams ->
-  Record (SetParams a)
-addOptions as polyParams = Record.insert (Proxy :: Proxy "options") as params
-  where
-  params :: Record (SetParamsEnum a)
-  params = Option.recordToRecord
-    ( optionRecord polyParams ::
-        OptionRecord (SetParamsRequiredEnum a) SetParamsOptionalEnum
-    )

--- a/src/Formlet/Ocelot/Checkbox.purs
+++ b/src/Formlet/Ocelot/Checkbox.purs
@@ -13,16 +13,20 @@ import Data.Set as Data.Set
 import Formlet as Formlet
 import Formlet.Ocelot.Enum as Formlet.Ocelot.Enum
 import Formlet.Render as Formlet.Render
+import Option as Option
+import Record as Record
 
 newtype Render a =
   Render
-    ( Array
-        { checked :: Boolean
-        , label :: String
-        , onChange :: Boolean -> a
-        , readonly :: Boolean
-        }
-    )
+    { columns :: Array Int -- NOTE positive integer (> 0), we use Array for its Semigroup instance and to collect column values
+    , options ::
+        Array
+          { checked :: Boolean
+          , label :: String
+          , onChange :: Boolean -> a
+          , readonly :: Boolean
+          }
+    }
 
 derive instance Newtype (Render a) _
 derive instance Functor Render
@@ -30,6 +34,34 @@ derive instance Functor Render
 derive newtype instance Semigroup (Render a)
 
 derive newtype instance Monoid (Render a)
+
+type SetParams a =
+  ( columns :: Maybe Int
+  , display :: a -> String
+  , options :: Array a
+  )
+
+type SetParamsEnum a =
+  ( columns :: Maybe Int
+  , display :: a -> String
+  )
+
+type SetParamsOptional =
+  ( columns :: Int
+  )
+
+type SetParamsOptionalEnum =
+  ( columns :: Int
+  )
+
+type SetParamsRequired a =
+  ( display :: a -> String
+  , options :: Array a
+  )
+
+type SetParamsRequiredEnum a =
+  ( display :: a -> String
+  )
 
 -- | A singleton checkbox Form that has `Boolean` as its input and output types.
 -- | Its render functor is also a `Monoid`, so it can be used in ado-notation.
@@ -63,52 +95,65 @@ checkbox ::
 checkbox label =
   Formlet.form_ \{ readonly } checked ->
     Render
-      [ { checked
-        , label
-        , onChange: if readonly then const (pure identity) else pure <<< const
-        , readonly
-        }
-      ]
+      { columns: []
+      , options:
+          [ { checked
+            , label
+            , onChange: if readonly then const (pure identity) else pure <<< const
+            , readonly
+            }
+          ]
+      }
 
 -- | A Form that is a set of checkboxes based on the given list of options,
 -- | each with its label and value. The result of a `checkboxSet` Form is the
 -- | `Set` of all selected options.
 checkboxSet ::
-  forall config options renders m a.
+  forall config options polyParams renders m a.
   Applicative m =>
   Ord a =>
-  { display :: a -> String
-  , options :: Array a
-  } ->
+  Option.FromRecord polyParams (SetParamsRequired a) SetParamsOptional =>
+  Option.ToRecord (SetParamsRequired a) SetParamsOptional (SetParams a) =>
+  Record polyParams ->
   Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (checkbox :: Render | renders)) m (Set a) (Set a)
-checkboxSet { display, options } =
+checkboxSet polyParams =
   Formlet.form \{ readonly } ->
     { render:
         \value ->
           Formlet.Render.inj
             { checkbox:
                 Render
-                  $ options
-                  # map \a ->
-                      let
-                        onChange :: Boolean -> m (Set a -> Set a)
-                        onChange =
-                          if _ then
-                            pure (Data.Set.insert a)
-                          else
-                            pure (Data.Set.delete a)
-                      in
-                        { checked: Data.Set.member a value
-                        , label: display a
-                        , onChange: if readonly then const (pure identity) else onChange
-                        , readonly
-                        }
+                  { columns: fromMaybe [] (pure <$> params.columns)
+                  , options:
+                      params.options
+                        # map \a ->
+                            let
+                              onChange :: Boolean -> m (Set a -> Set a)
+                              onChange =
+                                if _ then
+                                  pure (Data.Set.insert a)
+                                else
+                                  pure (Data.Set.delete a)
+                            in
+                              { checked: Data.Set.member a value
+                              , label: params.display a
+                              , onChange: if readonly then const (pure identity) else onChange
+                              , readonly
+                              }
+                  }
             }
     , validate: Right <<< validate
     }
   where
+  params :: Record (SetParams a)
+  params =
+    Option.recordToRecord
+      ( optionRecord polyParams ::
+          OptionRecord (SetParamsRequired a) SetParamsOptional
+      )
+
   validate :: Set a -> Set a
-  validate = Data.Set.intersection (Data.Set.fromFoldable options)
+  validate = Data.Set.intersection (Data.Set.fromFoldable params.options)
 
 -- | Inject a combination of `checkbox` Forms inside a larger Form structure.
 checkboxes ::
@@ -121,31 +166,42 @@ checkboxes = Formlet.mapRender (Formlet.Render.inj <<< { checkbox: _ })
 -- | A `checkboxSet` Form where all option values are filled in based on the
 -- | `Bounded` `Enum` instances for the value type.
 enumCheckboxSet ::
-  forall config options renders m a.
+  forall config options polyParams renders m a.
   Applicative m =>
   Ord a =>
   Bounded a =>
   Enum a =>
-  (a -> String) ->
+  Option.FromRecord polyParams (SetParamsRequiredEnum a) SetParamsOptionalEnum =>
+  Option.ToRecord (SetParamsRequiredEnum a) SetParamsOptionalEnum (SetParamsEnum a) =>
+  Record polyParams ->
   Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (checkbox :: Render | renders)) m (Set a) (Set a)
-enumCheckboxSet display =
-  checkboxSet
-    { display
-    , options: Formlet.Ocelot.Enum.enumOptions
-    }
+enumCheckboxSet = checkboxSet <<< addOptions Formlet.Ocelot.Enum.enumOptions
 
 -- | A `checkboxSet` Form where all option values are filled in with the
 -- | constructors of a `Generic` enum sum type.
 genericCheckboxSet ::
-  forall config options renders m a rep.
+  forall config options polyParams renders m a rep.
   Applicative m =>
   Ord a =>
   Generic a rep =>
   Formlet.Ocelot.Enum.GenericEnumOptions a rep =>
-  (a -> String) ->
+  Option.FromRecord polyParams (SetParamsRequiredEnum a) SetParamsOptionalEnum =>
+  Option.ToRecord (SetParamsRequiredEnum a) SetParamsOptionalEnum (SetParamsEnum a) =>
+  Record polyParams ->
   Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (checkbox :: Render | renders)) m (Set a) (Set a)
-genericCheckboxSet display =
-  checkboxSet
-    { display
-    , options: Formlet.Ocelot.Enum.genericEnumOptions
-    }
+genericCheckboxSet = checkboxSet <<< addOptions Formlet.Ocelot.Enum.genericEnumOptions
+
+addOptions ::
+  forall a polyParams.
+  Option.FromRecord polyParams (SetParamsRequiredEnum a) SetParamsOptionalEnum =>
+  Option.ToRecord (SetParamsRequiredEnum a) SetParamsOptionalEnum (SetParamsEnum a) =>
+  Array a ->
+  Record polyParams ->
+  Record (SetParams a)
+addOptions as polyParams = Record.insert (Proxy :: Proxy "options") as params
+  where
+  params :: Record (SetParamsEnum a)
+  params = Option.recordToRecord
+    ( optionRecord polyParams ::
+        OptionRecord (SetParamsRequiredEnum a) SetParamsOptionalEnum
+    )

--- a/src/Formlet/Ocelot/Checkbox/Halogen.purs
+++ b/src/Formlet/Ocelot/Checkbox/Halogen.purs
@@ -4,12 +4,15 @@ module Formlet.Ocelot.Checkbox.Halogen
 
 import CitizenNet.Prelude
 
+import Data.Array as Data.Array
+import Foreign.Object as Foreign.Object
 import Formlet.Ocelot.Checkbox as Formlet.Ocelot.Checkbox
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Events as Halogen.HTML.Events
 import Halogen.HTML.Properties as Halogen.HTML.Properties
 import Ocelot.Block.Checkbox as Ocelot.Block.Checkbox
+import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 
 render ::
   forall slots m config action.
@@ -17,14 +20,30 @@ render ::
   { readonly :: Boolean | config } ->
   Formlet.Ocelot.Checkbox.Render action ->
   Array (Halogen.ComponentHTML action slots m)
-render { key } { readonly } (Formlet.Ocelot.Checkbox.Render { options }) =
-  options
-    # map \option ->
-        Ocelot.Block.Checkbox.checkbox_
-          [ Halogen.HTML.Events.onChecked option.onChange
-          , Halogen.HTML.Properties.checked option.checked
-          , Halogen.HTML.Properties.disabled (readonly || option.readonly)
-          , Halogen.HTML.Properties.name key
+render { key } { readonly } (Formlet.Ocelot.Checkbox.Render { columns, options }) =
+  case Data.Array.uncons columns of
+    Nothing -> checkboxes
+    Just { head: numColumns } ->
+      [ Halogen.HTML.div
+          [ Ocelot.HTML.Properties.style
+              $ Foreign.Object.fromHomogeneous
+                  { "display": "grid"
+                  , "gap": "0.75rem"
+                  , "grid-template-columns": "repeat(" <> show numColumns <> ", 1fr)"
+                  }
           ]
-          [ Halogen.HTML.text option.label
-          ]
+          checkboxes
+      ]
+  where
+  checkboxes :: Array (Halogen.ComponentHTML action slots m)
+  checkboxes =
+    options
+      # map \option ->
+          Ocelot.Block.Checkbox.checkbox_
+            [ Halogen.HTML.Events.onChecked option.onChange
+            , Halogen.HTML.Properties.checked option.checked
+            , Halogen.HTML.Properties.disabled (readonly || option.readonly)
+            , Halogen.HTML.Properties.name key
+            ]
+            [ Halogen.HTML.text option.label
+            ]

--- a/src/Formlet/Ocelot/Checkbox/Halogen.purs
+++ b/src/Formlet/Ocelot/Checkbox/Halogen.purs
@@ -4,15 +4,12 @@ module Formlet.Ocelot.Checkbox.Halogen
 
 import CitizenNet.Prelude
 
-import Data.Array as Data.Array
-import Foreign.Object as Foreign.Object
 import Formlet.Ocelot.Checkbox as Formlet.Ocelot.Checkbox
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
 import Halogen.HTML.Events as Halogen.HTML.Events
 import Halogen.HTML.Properties as Halogen.HTML.Properties
 import Ocelot.Block.Checkbox as Ocelot.Block.Checkbox
-import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 
 render ::
   forall slots m config action.
@@ -20,30 +17,14 @@ render ::
   { readonly :: Boolean | config } ->
   Formlet.Ocelot.Checkbox.Render action ->
   Array (Halogen.ComponentHTML action slots m)
-render { key } { readonly } (Formlet.Ocelot.Checkbox.Render { columns, options }) =
-  case Data.Array.uncons columns of
-    Nothing -> checkboxes
-    Just { head: numColumns } ->
-      [ Halogen.HTML.div
-          [ Ocelot.HTML.Properties.style
-              $ Foreign.Object.fromHomogeneous
-                  { "display": "grid"
-                  , "gap": "0.75rem"
-                  , "grid-template-columns": "repeat(" <> show numColumns <> ", 1fr)"
-                  }
+render { key } { readonly } (Formlet.Ocelot.Checkbox.Render options) =
+  options
+    # map \option ->
+        Ocelot.Block.Checkbox.checkbox_
+          [ Halogen.HTML.Events.onChecked option.onChange
+          , Halogen.HTML.Properties.checked option.checked
+          , Halogen.HTML.Properties.disabled (readonly || option.readonly)
+          , Halogen.HTML.Properties.name key
           ]
-          checkboxes
-      ]
-  where
-  checkboxes :: Array (Halogen.ComponentHTML action slots m)
-  checkboxes =
-    options
-      # map \option ->
-          Ocelot.Block.Checkbox.checkbox_
-            [ Halogen.HTML.Events.onChecked option.onChange
-            , Halogen.HTML.Properties.checked option.checked
-            , Halogen.HTML.Properties.disabled (readonly || option.readonly)
-            , Halogen.HTML.Properties.name key
-            ]
-            [ Halogen.HTML.text option.label
-            ]
+          [ Halogen.HTML.text option.label
+          ]

--- a/src/Formlet/Ocelot/Checkbox/Halogen.purs
+++ b/src/Formlet/Ocelot/Checkbox/Halogen.purs
@@ -17,7 +17,7 @@ render ::
   { readonly :: Boolean | config } ->
   Formlet.Ocelot.Checkbox.Render action ->
   Array (Halogen.ComponentHTML action slots m)
-render { key } { readonly } (Formlet.Ocelot.Checkbox.Render options) =
+render { key } { readonly } (Formlet.Ocelot.Checkbox.Render { options }) =
   options
     # map \option ->
         Ocelot.Block.Checkbox.checkbox_

--- a/src/Formlet/Ocelot/CheckboxSet.purs
+++ b/src/Formlet/Ocelot/CheckboxSet.purs
@@ -1,0 +1,158 @@
+module Formlet.Ocelot.CheckboxSet
+  ( Render(..)
+  , checkboxSet
+  , enumCheckboxSet
+  , genericCheckboxSet
+  ) where
+
+import CitizenNet.Prelude
+
+import Data.Set as Data.Set
+import Formlet as Formlet
+import Formlet.Ocelot.Enum as Formlet.Ocelot.Enum
+import Formlet.Render as Formlet.Render
+import Option as Option
+import Record as Record
+
+type Form config m options render a =
+  Formlet.Form
+    { readonly :: Boolean | config }
+    (Formlet.Render.Render options (checkboxSet :: Render | render))
+    m
+    (Set a)
+    (Set a)
+
+newtype Render a =
+  Render
+    { columns :: Int -- NOTE positive integer (> 0)
+    , options ::
+        Array
+          { checked :: Boolean
+          , label :: String
+          , onChange :: Boolean -> a
+          , readonly :: Boolean
+          }
+    }
+
+derive instance Newtype (Render a) _
+derive instance Functor Render
+
+type Params a =
+  ( columns :: Maybe Int
+  , display :: a -> String
+  , options :: Array a
+  )
+
+type ParamsEnum a =
+  ( columns :: Maybe Int
+  , display :: a -> String
+  )
+
+type ParamsOptional =
+  ( columns :: Int
+  )
+
+type ParamsOptionalEnum =
+  ( columns :: Int
+  )
+
+type ParamsRequired a =
+  ( display :: a -> String
+  , options :: Array a
+  )
+
+type ParamsRequiredEnum a =
+  ( display :: a -> String
+  )
+
+-- | A Form that is a set of checkboxes based on the given list of options,
+-- | each with its label and value. The result of a `checkboxSet` Form is the
+-- | `Set` of all selected options.
+checkboxSet ::
+  forall a config polyParams m options render.
+  Applicative m =>
+  Ord a =>
+  Option.FromRecord polyParams (ParamsRequired a) ParamsOptional =>
+  Option.ToRecord (ParamsRequired a) ParamsOptional (Params a) =>
+  Record polyParams ->
+  Form config m options render a
+checkboxSet polyParams =
+  Formlet.form \{ readonly } ->
+    { render: \value ->
+        Formlet.Render.inj
+          { checkboxSet:
+              Render
+                { columns: fromMaybe 1 params.columns
+                , options:
+                    params.options
+                      # map \a ->
+                          let
+                            onChange :: Boolean -> m (Set a -> Set a)
+                            onChange =
+                              if _ then
+                                pure (Data.Set.insert a)
+                              else
+                                pure (Data.Set.delete a)
+                          in
+                            { checked: Data.Set.member a value
+                            , label: params.display a
+                            , onChange: if readonly then const (pure identity) else onChange
+                            , readonly
+                            }
+                }
+          }
+    , validate: Right <<< validate
+    }
+  where
+  params :: Record (Params a)
+  params =
+    Option.recordToRecord
+      ( optionRecord polyParams ::
+          OptionRecord (ParamsRequired a) ParamsOptional
+      )
+
+  validate :: Set a -> Set a
+  validate = Data.Set.intersection (Data.Set.fromFoldable params.options)
+
+-- | A `checkboxSet` Form where all option values are filled in based on the
+-- | `Bounded` `Enum` instances for the value type.
+enumCheckboxSet ::
+  forall a config options m polyParams render.
+  Applicative m =>
+  Ord a =>
+  Bounded a =>
+  Enum a =>
+  Option.FromRecord polyParams (ParamsRequiredEnum a) ParamsOptionalEnum =>
+  Option.ToRecord (ParamsRequiredEnum a) ParamsOptionalEnum (ParamsEnum a) =>
+  Record polyParams ->
+  Form config m options render a
+enumCheckboxSet = checkboxSet <<< addOptions Formlet.Ocelot.Enum.enumOptions
+
+-- | A `checkboxSet` Form where all option values are filled in with the
+-- | constructors of a `Generic` enum sum type.
+genericCheckboxSet ::
+  forall a config options m polyParams render rep.
+  Applicative m =>
+  Ord a =>
+  Generic a rep =>
+  Formlet.Ocelot.Enum.GenericEnumOptions a rep =>
+  Option.FromRecord polyParams (ParamsRequiredEnum a) ParamsOptionalEnum =>
+  Option.ToRecord (ParamsRequiredEnum a) ParamsOptionalEnum (ParamsEnum a) =>
+  Record polyParams ->
+  Form config m options render a
+genericCheckboxSet = checkboxSet <<< addOptions Formlet.Ocelot.Enum.genericEnumOptions
+
+addOptions ::
+  forall a polyParams.
+  Option.FromRecord polyParams (ParamsRequiredEnum a) ParamsOptionalEnum =>
+  Option.ToRecord (ParamsRequiredEnum a) ParamsOptionalEnum (ParamsEnum a) =>
+  Array a ->
+  Record polyParams ->
+  Record (Params a)
+addOptions as polyParams = Record.insert (Proxy :: Proxy "options") as params
+  where
+  params :: Record (ParamsEnum a)
+  params = Option.recordToRecord
+    ( optionRecord polyParams ::
+        OptionRecord (ParamsRequiredEnum a) ParamsOptionalEnum
+    )

--- a/src/Formlet/Ocelot/CheckboxSet.purs
+++ b/src/Formlet/Ocelot/CheckboxSet.purs
@@ -30,7 +30,6 @@ newtype Render a =
           { checked :: Boolean
           , label :: String
           , onChange :: Boolean -> a
-          , readonly :: Boolean
           }
     }
 
@@ -97,7 +96,6 @@ checkboxSet polyParams =
                             { checked: Data.Set.member a value
                             , label: params.display a
                             , onChange: if readonly then const (pure identity) else onChange
-                            , readonly
                             }
                 }
           }

--- a/src/Formlet/Ocelot/CheckboxSet/Halogen.purs
+++ b/src/Formlet/Ocelot/CheckboxSet/Halogen.purs
@@ -40,4 +40,11 @@ render { key } { readonly } (Formlet.Ocelot.CheckboxSet.Render { columns, option
           Formlet.Ocelot.Checkbox.Halogen.render
             { key }
             { readonly }
-            (Formlet.Ocelot.Checkbox.Render [ option ])
+            ( Formlet.Ocelot.Checkbox.Render
+                [ { checked: option.checked
+                  , label: option.label
+                  , onChange: option.onChange
+                  , readonly
+                  }
+                ]
+            )

--- a/src/Formlet/Ocelot/CheckboxSet/Halogen.purs
+++ b/src/Formlet/Ocelot/CheckboxSet/Halogen.purs
@@ -1,0 +1,43 @@
+module Formlet.Ocelot.CheckboxSet.Halogen
+  ( render
+  ) where
+
+import CitizenNet.Prelude
+
+import Foreign.Object as Foreign.Object
+import Formlet.Ocelot.Checkbox as Formlet.Ocelot.Checkbox
+import Formlet.Ocelot.Checkbox.Halogen as Formlet.Ocelot.Checkbox.Halogen
+import Formlet.Ocelot.CheckboxSet as Formlet.Ocelot.CheckboxSet
+import Halogen as Halogen
+import Halogen.HTML as Halogen.HTML
+import Ocelot.HTML.Properties as Ocelot.HTML.Properties
+
+render ::
+  forall slots m config action.
+  { key :: String } ->
+  { readonly :: Boolean | config } ->
+  Formlet.Ocelot.CheckboxSet.Render action ->
+  Array (Halogen.ComponentHTML action slots m)
+render { key } { readonly } (Formlet.Ocelot.CheckboxSet.Render { columns, options }) =
+  if columns <= 1 then
+    checkboxes
+  else
+    [ Halogen.HTML.div
+        [ Ocelot.HTML.Properties.style
+            $ Foreign.Object.fromHomogeneous
+                { "display": "grid"
+                , "gap": "0.75rem"
+                , "grid-template-columns": "repeat(" <> show columns <> ", 1fr)"
+                }
+        ]
+        checkboxes
+    ]
+  where
+  checkboxes :: Array (Halogen.ComponentHTML action slots m)
+  checkboxes =
+    options
+      # foldMap \option ->
+          Formlet.Ocelot.Checkbox.Halogen.render
+            { key }
+            { readonly }
+            (Formlet.Ocelot.Checkbox.Render [ option ])

--- a/src/Formlet/Ocelot/Render.purs
+++ b/src/Formlet/Ocelot/Render.purs
@@ -17,6 +17,7 @@ import CitizenNet.Prelude
 import Formlet as Formlet
 import Formlet.Ocelot.Array as Formlet.Ocelot.Array
 import Formlet.Ocelot.Checkbox as Formlet.Ocelot.Checkbox
+import Formlet.Ocelot.CheckboxSet as Formlet.Ocelot.CheckboxSet
 import Formlet.Ocelot.DateTime as Formlet.Ocelot.DateTime
 import Formlet.Ocelot.Dropdown as Formlet.Ocelot.Dropdown
 import Formlet.Ocelot.File as Formlet.Ocelot.File
@@ -63,6 +64,7 @@ type Render options renders =
 type Renders options renders =
   ( array :: Formlet.Ocelot.Array.Render (Forest options renders)
   , checkbox :: Formlet.Ocelot.Checkbox.Render
+  , checkboxSet :: Formlet.Ocelot.CheckboxSet.Render
   , dateTime :: Formlet.Ocelot.DateTime.Render
   , dropdown :: Formlet.Ocelot.Dropdown.Render
   , file :: Formlet.Ocelot.File.Render

--- a/src/Formlet/Ocelot/Render/Halogen.purs
+++ b/src/Formlet/Ocelot/Render/Halogen.purs
@@ -10,6 +10,7 @@ import Data.Functor.Variant as Data.Functor.Variant
 import Formlet.Field.Halogen as Formlet.Field.Halogen
 import Formlet.Ocelot.Array.Halogen as Formlet.Ocelot.Array.Halogen
 import Formlet.Ocelot.Checkbox.Halogen as Formlet.Ocelot.Checkbox.Halogen
+import Formlet.Ocelot.CheckboxSet.Halogen as Formlet.Ocelot.CheckboxSet.Halogen
 import Formlet.Ocelot.DateTime.Halogen as Formlet.Ocelot.DateTime.Halogen
 import Formlet.Ocelot.Dropdown.Halogen as Formlet.Ocelot.Dropdown.Halogen
 import Formlet.Ocelot.File.Halogen as Formlet.Ocelot.File.Halogen
@@ -69,6 +70,7 @@ render renderOtherOptions renderOthers config' =
             )
             config
       , checkbox: Formlet.Ocelot.Checkbox.Halogen.render { key } config
+      , checkboxSet: Formlet.Ocelot.CheckboxSet.Halogen.render { key } config
       , dateTime: Formlet.Ocelot.DateTime.Halogen.render config
       , dropdown: Formlet.Ocelot.Dropdown.Halogen.render config
       , file: Formlet.Ocelot.File.Halogen.render config

--- a/test/Test/Formlet/Ocelot/Checkbox.purs
+++ b/test/Test/Formlet/Ocelot/Checkbox.purs
@@ -43,7 +43,7 @@ checkboxSuite = do
 
           onChange' :: Maybe (Boolean -> Boolean -> Boolean)
           onChange' = ado
-            option <- Data.Array.head (un Formlet.Ocelot.Checkbox.Render rendered)
+            option <- Data.Array.head (un Formlet.Ocelot.Checkbox.Render rendered).options
             in option.onChange
         in
           case onChange' of
@@ -79,6 +79,7 @@ checkboxSuite = do
             Partial.Unsafe.unsafePartial
               $ Data.Maybe.fromJust
               $ Data.Array.NonEmpty.fromArray
+              $ _.options
               $ un Formlet.Ocelot.Checkbox.Render rendered
         selectedOption <- Test.QuickCheck.Gen.elements options
         let
@@ -113,7 +114,7 @@ checkboxSetSuite =
           expected :: Array String
           expected = map (_ <> "a") options
         in
-          expected === map _.label (un Formlet.Ocelot.Checkbox.Render rendered)
+          expected === map _.label (un Formlet.Ocelot.Checkbox.Render rendered).options
     Test.Unit.test "A `checkboxSet` option's `onChange` should appropriately change the Form's value" do
       Test.Unit.QuickCheck.quickCheck \options checked -> do
         value <- Data.Set.fromFoldable <$> genTake (Data.Array.NonEmpty.toArray options)
@@ -198,7 +199,7 @@ checkboxSetSuite =
           result =
             Formlet.validate
               ( Formlet.Ocelot.Checkbox.checkboxSet
-                  { display: identity
+                  { display: identity :: String -> String
                   , options
                   } ::
                   Formlet.Form _ _ Data.Identity.Identity _ _
@@ -264,6 +265,7 @@ testRenderCheckboxSetOptions { display, options, readonly, value } =
   Partial.Unsafe.unsafePartial
     $ Data.Maybe.fromJust
     $ Data.Array.NonEmpty.fromArray
+    $ _.options
     $ Formlet.Render.match { checkbox: un Formlet.Ocelot.Checkbox.Render <<< map (un Data.Identity.Identity) }
     $ Formlet.render
         ( Formlet.Ocelot.Checkbox.checkboxSet

--- a/test/Test/Formlet/Ocelot/Checkbox.purs
+++ b/test/Test/Formlet/Ocelot/Checkbox.purs
@@ -8,8 +8,6 @@ import Data.Array as Data.Array
 import Data.Array.NonEmpty as Data.Array.NonEmpty
 import Data.Identity as Data.Identity
 import Data.Maybe as Data.Maybe
-import Data.Ord as Data.Ord
-import Data.Set as Data.Set
 import Formlet as Formlet
 import Formlet.Ocelot.Checkbox as Formlet.Ocelot.Checkbox
 import Formlet.Render as Formlet.Render
@@ -24,7 +22,6 @@ suite :: Test.Unit.TestSuite
 suite =
   Test.Unit.suite "Formlet.Ocelot.Checkbox" do
     checkboxSuite
-    checkboxSetSuite
 
 checkboxSuite :: Test.Unit.TestSuite
 checkboxSuite = do
@@ -43,7 +40,7 @@ checkboxSuite = do
 
           onChange' :: Maybe (Boolean -> Boolean -> Boolean)
           onChange' = ado
-            option <- Data.Array.head (un Formlet.Ocelot.Checkbox.Render rendered).options
+            option <- Data.Array.head (un Formlet.Ocelot.Checkbox.Render rendered)
             in option.onChange
         in
           case onChange' of
@@ -79,7 +76,6 @@ checkboxSuite = do
             Partial.Unsafe.unsafePartial
               $ Data.Maybe.fromJust
               $ Data.Array.NonEmpty.fromArray
-              $ _.options
               $ un Formlet.Ocelot.Checkbox.Render rendered
         selectedOption <- Test.QuickCheck.Gen.elements options
         let
@@ -92,186 +88,3 @@ checkboxSuite = do
               "Bar" -> value { bar = checked }
               _ -> value
         pure $ expected === selectedOption.onChange checked value
-
-checkboxSetSuite :: Test.Unit.TestSuite
-checkboxSetSuite =
-  Test.Unit.suite "`checkboxSet`" do
-    Test.Unit.test "`checkboxSet` should render all options" do
-      Test.Unit.QuickCheck.quickCheck \options ->
-        let
-          rendered :: Formlet.Ocelot.Checkbox.Render (Set String -> Set String)
-          rendered =
-            Formlet.Render.match { checkbox: map (un Data.Identity.Identity) }
-              $ Formlet.render
-                  ( Formlet.Ocelot.Checkbox.checkboxSet
-                      { display: (_ <> "a")
-                      , options
-                      }
-                  )
-                  { readonly: false }
-                  Data.Set.empty
-
-          expected :: Array String
-          expected = map (_ <> "a") options
-        in
-          expected === map _.label (un Formlet.Ocelot.Checkbox.Render rendered).options
-    Test.Unit.test "A `checkboxSet` option's `onChange` should appropriately change the Form's value" do
-      Test.Unit.QuickCheck.quickCheck \options checked -> do
-        value <- Data.Set.fromFoldable <$> genTake (Data.Array.NonEmpty.toArray options)
-        let
-          rendered ::
-            NonEmptyArray
-              { checked :: Boolean
-              , label :: String
-              , onChange :: Boolean -> Set String -> Set String
-              , readonly :: Boolean
-              }
-          rendered =
-            testRenderCheckboxSetOptions
-              { display: identity
-              , options
-              , readonly: false
-              , value
-              }
-        selectedOption <- Test.QuickCheck.Gen.elements rendered
-        let
-          expected :: Set String
-          expected =
-            if checked then
-              Data.Set.insert selectedOption.label value
-            else
-              Data.Set.delete selectedOption.label value
-        pure $ expected === selectedOption.onChange checked value
-    Test.Unit.test "`checkboxSet`'s selected values which are not in the options should not appear in the rendered value" do
-      Test.Unit.QuickCheck.quickCheck \(value' :: Array String) options ->
-        let
-          value :: Set String
-          value = Data.Set.fromFoldable value'
-
-          rendered ::
-            NonEmptyArray
-              { checked :: Boolean
-              , label :: String
-              , onChange :: Boolean -> Set String -> Set String
-              , readonly :: Boolean
-              }
-          rendered =
-            testRenderCheckboxSetOptions
-              { display: identity
-              , options
-              , readonly: false
-              , value
-              }
-
-          -- Here we choose to test whether no values in the Form `value` that
-          -- do not exist in the `options` end up appearing in the rendered
-          -- `options`, instead of mapping over the `options`, as we already
-          -- know from a previous test that `checkboxSet` renders only the
-          -- `options`.
-          expected :: Array { checked :: Boolean, label :: String }
-          expected =
-            Data.Array.sortWith _.label $ value
-              # foldMap \label ->
-                  if Data.Array.NonEmpty.elem label options then
-                    [ { checked: true, label } ]
-                  else
-                    []
-
-          actual :: Array { checked :: Boolean, label :: String }
-          actual =
-            Data.Array.nubBy (Data.Ord.comparing _.label)
-              $ Data.Array.sortWith _.label
-              $ rendered
-              # foldMap \{ checked, label } ->
-                  if checked then
-                    [ { checked, label } ]
-                  else
-                    []
-        in
-          expected === actual
-    Test.Unit.test "`checkboxSet`'s validated result should not include any values that are not in the options" do
-      Test.Unit.QuickCheck.quickCheck \(value' :: Array String) options ->
-        let
-          value :: Set String
-          value = Data.Set.fromFoldable value'
-
-          result :: Either (Array String) (Set String)
-          result =
-            Formlet.validate
-              ( Formlet.Ocelot.Checkbox.checkboxSet
-                  { display: identity :: String -> String
-                  , options
-                  } ::
-                  Formlet.Form _ _ Data.Identity.Identity _ _
-              )
-              { readonly: false }
-              value
-
-          expected :: Either (Array String) (Set String)
-          expected = Right $ Data.Set.intersection value (Data.Set.fromFoldable options)
-        in
-          expected === result
-    Test.Unit.test "`checkboxSet` should not change its value if `readonly = true`" do
-      Test.Unit.QuickCheck.quickCheck \options checked readonly -> do
-        value <- Data.Set.fromFoldable <$> genTake (Data.Array.NonEmpty.toArray options)
-        let
-          rendered ::
-            NonEmptyArray
-              { checked :: Boolean
-              , label :: String
-              , onChange :: Boolean -> Set String -> Set String
-              , readonly :: Boolean
-              }
-          rendered =
-            testRenderCheckboxSetOptions
-              { display: identity
-              , options
-              , readonly
-              , value
-              }
-        selectedOption <- Test.QuickCheck.Gen.elements rendered
-        let
-          expected :: Set String
-          expected = case readonly, checked of
-            true, true -> value
-            true, false -> value
-            false, true -> Data.Set.insert selectedOption.label value
-            false, false -> Data.Set.delete selectedOption.label value
-        pure $ expected === selectedOption.onChange checked value
-
-genTake :: forall a. Array a -> Test.QuickCheck.Gen.Gen (Array a)
-genTake xs = do
-  n <- Test.QuickCheck.Gen.chooseInt 0 (Data.Array.length xs - 1)
-  Data.Array.take n <$> Test.QuickCheck.Gen.shuffle (xs)
-
-testRenderCheckboxSetOptions ::
-  forall a.
-  Ord a =>
-  { display :: a -> String
-  , options :: NonEmptyArray a
-  , readonly :: Boolean
-  , value :: Set a
-  } ->
-  NonEmptyArray
-    { checked :: Boolean
-    , label :: String
-    , onChange :: Boolean -> Set a -> Set a
-    , readonly :: Boolean
-    }
-testRenderCheckboxSetOptions { display, options, readonly, value } =
-  -- We know here that the `options` is a `NonEmptyArray` and we need to make
-  -- the set of rendered options into one in order to use
-  -- `Test.QuickCheck.Gen.elements`.
-  Partial.Unsafe.unsafePartial
-    $ Data.Maybe.fromJust
-    $ Data.Array.NonEmpty.fromArray
-    $ _.options
-    $ Formlet.Render.match { checkbox: un Formlet.Ocelot.Checkbox.Render <<< map (un Data.Identity.Identity) }
-    $ Formlet.render
-        ( Formlet.Ocelot.Checkbox.checkboxSet
-            { display
-            , options: Data.Array.NonEmpty.toArray options
-            }
-        )
-        { readonly }
-        value

--- a/test/Test/Formlet/Ocelot/CheckboxSet.purs
+++ b/test/Test/Formlet/Ocelot/CheckboxSet.purs
@@ -1,0 +1,205 @@
+module Test.Formlet.Ocelot.CheckboxSet
+  ( suite
+  ) where
+
+import CitizenNet.Prelude
+
+import Data.Array as Data.Array
+import Data.Array.NonEmpty as Data.Array.NonEmpty
+import Data.Identity as Data.Identity
+import Data.Maybe as Data.Maybe
+import Data.Ord as Data.Ord
+import Data.Set as Data.Set
+import Formlet as Formlet
+import Formlet.Render as Formlet.Render
+import Formlet.Ocelot.CheckboxSet as Formlet.Ocelot.CheckboxSet
+import Partial.Unsafe as Partial.Unsafe
+import Test.QuickCheck ((===))
+import Test.QuickCheck.Gen as Test.QuickCheck.Gen
+import Test.Unit as Test.Unit
+import Test.Unit.QuickCheck as Test.Unit.QuickCheck
+
+suite :: Test.Unit.TestSuite
+suite =
+  Test.Unit.suite "Formlet.Ocelot.CheckboxSet" do
+    checkboxSetSuite
+
+checkboxSetSuite :: Test.Unit.TestSuite
+checkboxSetSuite =
+  Test.Unit.suite "`checkboxSet`" do
+    Test.Unit.test "`checkboxSet` should render all options" do
+      Test.Unit.QuickCheck.quickCheck \options ->
+        let
+          rendered :: Formlet.Ocelot.CheckboxSet.Render (Set String -> Set String)
+          rendered =
+            Formlet.Render.match { checkboxSet: map (un Data.Identity.Identity) }
+              $ Formlet.render
+                  ( Formlet.Ocelot.CheckboxSet.checkboxSet
+                      { display: (_ <> "a")
+                      , options
+                      }
+                  )
+                  { readonly: false }
+                  Data.Set.empty
+
+          expected :: Array String
+          expected = map (_ <> "a") options
+        in
+          expected === map _.label (un Formlet.Ocelot.CheckboxSet.Render rendered).options
+    Test.Unit.test "A `checkboxSet` option's `onChange` should appropriately change the Form's value" do
+      Test.Unit.QuickCheck.quickCheck \options checked -> do
+        value <- Data.Set.fromFoldable <$> genTake (Data.Array.NonEmpty.toArray options)
+        let
+          rendered ::
+            NonEmptyArray
+              { checked :: Boolean
+              , label :: String
+              , onChange :: Boolean -> Set String -> Set String
+              }
+          rendered =
+            testRenderCheckboxSetOptions
+              { display: identity
+              , options
+              , readonly: false
+              , value
+              }
+        selectedOption <- Test.QuickCheck.Gen.elements rendered
+        let
+          expected :: Set String
+          expected =
+            if checked then
+              Data.Set.insert selectedOption.label value
+            else
+              Data.Set.delete selectedOption.label value
+        pure $ expected === selectedOption.onChange checked value
+    Test.Unit.test "`checkboxSet`'s selected values which are not in the options should not appear in the rendered value" do
+      Test.Unit.QuickCheck.quickCheck \(value' :: Array String) options ->
+        let
+          value :: Set String
+          value = Data.Set.fromFoldable value'
+
+          rendered ::
+            NonEmptyArray
+              { checked :: Boolean
+              , label :: String
+              , onChange :: Boolean -> Set String -> Set String
+              }
+          rendered =
+            testRenderCheckboxSetOptions
+              { display: identity
+              , options
+              , readonly: false
+              , value
+              }
+
+          -- Here we choose to test whether no values in the Form `value` that
+          -- do not exist in the `options` end up appearing in the rendered
+          -- `options`, instead of mapping over the `options`, as we already
+          -- know from a previous test that `checkboxSet` renders only the
+          -- `options`.
+          expected :: Array { checked :: Boolean, label :: String }
+          expected =
+            Data.Array.sortWith _.label $ value
+              # foldMap \label ->
+                  if Data.Array.NonEmpty.elem label options then
+                    [ { checked: true, label } ]
+                  else
+                    []
+
+          actual :: Array { checked :: Boolean, label :: String }
+          actual =
+            Data.Array.nubBy (Data.Ord.comparing _.label)
+              $ Data.Array.sortWith _.label
+              $ rendered
+              # foldMap \{ checked, label } ->
+                  if checked then
+                    [ { checked, label } ]
+                  else
+                    []
+        in
+          expected === actual
+    Test.Unit.test "`checkboxSet`'s validated result should not include any values that are not in the options" do
+      Test.Unit.QuickCheck.quickCheck \(value' :: Array String) options ->
+        let
+          value :: Set String
+          value = Data.Set.fromFoldable value'
+
+          result :: Either (Array String) (Set String)
+          result =
+            Formlet.validate
+              ( Formlet.Ocelot.CheckboxSet.checkboxSet
+                  { display: identity :: String -> String
+                  , options
+                  } ::
+                  Formlet.Form _ _ Data.Identity.Identity _ _
+              )
+              { readonly: false }
+              value
+
+          expected :: Either (Array String) (Set String)
+          expected = Right $ Data.Set.intersection value (Data.Set.fromFoldable options)
+        in
+          expected === result
+    Test.Unit.test "`checkboxSet` should not change its value if `readonly = true`" do
+      Test.Unit.QuickCheck.quickCheck \options checked readonly -> do
+        value <- Data.Set.fromFoldable <$> genTake (Data.Array.NonEmpty.toArray options)
+        let
+          rendered ::
+            NonEmptyArray
+              { checked :: Boolean
+              , label :: String
+              , onChange :: Boolean -> Set String -> Set String
+              }
+          rendered =
+            testRenderCheckboxSetOptions
+              { display: identity
+              , options
+              , readonly
+              , value
+              }
+        selectedOption <- Test.QuickCheck.Gen.elements rendered 
+        let
+          expected :: Set String
+          expected = case readonly, checked of
+            true, true -> value
+            true, false -> value
+            false, true -> Data.Set.insert selectedOption.label value
+            false, false -> Data.Set.delete selectedOption.label value
+        pure $ expected === selectedOption.onChange checked value
+
+genTake :: forall a. Array a -> Test.QuickCheck.Gen.Gen (Array a)
+genTake xs = do
+  n <- Test.QuickCheck.Gen.chooseInt 0 (Data.Array.length xs - 1)
+  Data.Array.take n <$> Test.QuickCheck.Gen.shuffle (xs)
+
+testRenderCheckboxSetOptions ::
+  forall a.
+  Ord a =>
+  { display :: a -> String
+  , options :: NonEmptyArray a
+  , readonly :: Boolean
+  , value :: Set a
+  } ->
+  NonEmptyArray
+    { checked :: Boolean
+    , label :: String
+    , onChange :: Boolean -> Set a -> Set a
+    }
+testRenderCheckboxSetOptions { display, options, readonly, value } =
+  -- We know here that the `options` is a `NonEmptyArray` and we need to make
+  -- the set of rendered options into one in order to use
+  -- `Test.QuickCheck.Gen.elements`.
+  Partial.Unsafe.unsafePartial
+    $ Data.Maybe.fromJust
+    $ Data.Array.NonEmpty.fromArray
+    $ _.options
+    $ un Formlet.Ocelot.CheckboxSet.Render
+    $ Formlet.Render.match { checkboxSet: map (un Data.Identity.Identity) }
+    $ Formlet.render
+        ( Formlet.Ocelot.CheckboxSet.checkboxSet
+            { display
+            , options: Data.Array.NonEmpty.toArray options
+            }
+        )
+        { readonly }
+        value


### PR DESCRIPTION
## What does this pull request do?

We want to be able to render a checkbox set horizontally. In order to do so, we need to be able to specify the number of columns to be used during rendering as we do for tabular select.

## Where should the reviewer start?
All at once.

## How should this be manually tested?

Automated testing should be sufficient. It would be nice to add a storybook for these components though.

## Other Notes:

Since `Formlet.Ocelot.Checkbox.Render` implements `Semigroup`, `columns` must be a `Monoid`. While we could select any arbitrary monoid (such as `First Int`), we decide to use `Array Int` to preserve values and ordering. While it's unlikely any `render` function will make use of this sequence, we shouldn't make assumptions.

Also, I'm requesting a review from Wenbo since he's most familiar with `tabularSelect` upon which this solution is based.
