### PR TITLE
API-3335 Upgrade Ocelot and Support Default Time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "purescript-formlet-ocelot",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "big-integer": "^1.6.51",
+        "moment-timezone": "^0.5.43"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    }
+  },
+  "dependencies": {
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+    },
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
+    "moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "requires": {
+        "moment": "^2.29.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "big-integer": "1.6.51",
+    "moment-timezone": "0.5.43"
+  }
+}

--- a/packages.dhall
+++ b/packages.dhall
@@ -227,7 +227,7 @@ let additions =
               , "variant"
               ]
           , repo = "https://github.com/citizennet/purescript-ocelot.git"
-          , version = "v0.34.2"
+          , version = "v0.35.0"
           }
       , option =
           { dependencies =

--- a/spago.template.dhall
+++ b/spago.template.dhall
@@ -42,6 +42,7 @@ in
       , "prelude"
       , "profunctor-lenses"
       , "quickcheck"
+      , "record"
       , "remotedata"
       , "strings"
       , "test-unit"

--- a/src/Formlet/Ocelot/DateTime.purs
+++ b/src/Formlet/Ocelot/DateTime.purs
@@ -6,6 +6,7 @@ module Formlet.Ocelot.DateTime
 
 import CitizenNet.Prelude
 
+import Data.Time as Data.Time
 import Formlet as Formlet
 import Formlet.Render as Formlet.Render
 import Option as Option
@@ -17,11 +18,13 @@ type Interval =
   }
 
 type Params =
-  ( interval :: Maybe Interval
+  ( defaultTime :: Maybe Data.Time.Time
+  , interval :: Maybe Interval
   )
 
 type ParamsOptional =
-  ( interval :: Interval
+  ( defaultTime :: Data.Time.Time
+  , interval :: Interval
   )
 
 type ParamsRequired =
@@ -29,7 +32,8 @@ type ParamsRequired =
 
 newtype Render action =
   Render
-    { interval :: Maybe Interval
+    { defaultTime :: Maybe Data.Time.Time
+    , interval :: Maybe Interval
     , onChange :: Maybe DateTime -> action
     , readonly :: Boolean
     , timezone :: TimeZone.TimeZone
@@ -59,7 +63,8 @@ dateTime polyParams =
     Formlet.Render.inj
       { dateTime:
           Render
-            { interval: params.interval
+            { defaultTime: params.defaultTime
+            , interval: params.interval
             , onChange: if readonly then const (pure identity) else pure <<< const
             , readonly
             , timezone

--- a/src/Formlet/Ocelot/DateTime/Halogen.purs
+++ b/src/Formlet/Ocelot/DateTime/Halogen.purs
@@ -9,6 +9,7 @@ module Formlet.Ocelot.DateTime.Halogen
 import CitizenNet.Prelude
 
 import Data.DateTime as Data.DateTime
+import Data.Time as Data.Time
 import Formlet.Ocelot.DateTime as Formlet.Ocelot.DateTime
 import Halogen as Halogen
 import Halogen.HTML as Halogen.HTML
@@ -30,7 +31,8 @@ render { readonly } (Formlet.Ocelot.DateTime.Render render') =
       (Proxy :: Proxy "dateTimePicker")
       unit
       component
-      { disabled: readonly || render'.readonly
+      { defaultTime: render'.defaultTime
+      , disabled: readonly || render'.readonly
       , interval: render'.interval
       , selection: render'.value
       , targetDate: Nothing
@@ -53,7 +55,8 @@ type ChildSlots =
   )
 
 type Input =
-  { disabled :: Boolean
+  { defaultTime :: Maybe Data.Time.Time
+  , disabled :: Boolean
   , interval :: Maybe Ocelot.DateTimePicker.Interval
   , selection :: Maybe DateTime
   , targetDate :: Maybe (Data.DateTime.Year /\ Data.DateTime.Month)
@@ -115,7 +118,8 @@ component =
           (Proxy :: Proxy "dateTimePicker")
           unit
           Ocelot.DateTimePicker.component
-          { disabled: state.disabled
+          { defaultTime: state.defaultTime
+          , disabled: state.disabled
           , interval: do
               interval <- state.interval
               pure


### PR DESCRIPTION
## What does this pull request do?

Upgrade `ocelot` to `v0.35.0` and support `defaultTime` in `Formlet.Ocelot.DateTime`.
