### PR TITLE
API-3352 Add `Formlet.Ocelot.RadioGroup`

### DIFF
--- a/src/Formlet/Ocelot/Radio/Halogen.purs
+++ b/src/Formlet/Ocelot/Radio/Halogen.purs
@@ -19,7 +19,7 @@ render ::
   Array (Halogen.ComponentHTML action slots m)
 render { key } { readonly } (Formlet.Ocelot.Radio.Render render') =
   render'.options
-    # map \{ label, onSelect } ->
+    # map \({ label, onSelect }) ->
         Ocelot.Block.Radio.radio_
           [ Halogen.HTML.Events.onClick \_ -> onSelect
           , Halogen.HTML.Properties.checked (render'.value == Just label)

--- a/src/Formlet/Ocelot/RadioGroup.purs
+++ b/src/Formlet/Ocelot/RadioGroup.purs
@@ -1,0 +1,118 @@
+module Formlet.Ocelot.RadioGroup
+  ( Render(..)
+  , enumRadioGroup
+  , genericRadioGroup
+  , radioGroup
+  ) where
+
+import CitizenNet.Prelude
+
+import Data.Array as Data.Array
+import Formlet as Formlet
+import Formlet.Ocelot.Enum as Formlet.Ocelot.Enum
+import Formlet.Render as Formlet.Render
+
+newtype Render render action =
+  Render
+    { options ::
+        Array
+          { label :: String
+          , onSelect :: action
+          }
+    , readonly :: Boolean
+    , render :: render action
+    , value :: Maybe String
+    }
+
+derive instance Newtype (Render render action) _
+derive instance Functor render => Functor (Render render)
+
+type State state a =
+  { formState :: state
+  , selection :: Maybe a
+  }
+
+-- | A `radio` Form where all option values are filled in based on the `Bounded`
+-- | `Enum` instances for the value type.
+enumRadioGroup ::
+  forall config options render renders result m a state.
+  Applicative m =>
+  Eq a =>
+  Bounded a =>
+  Enum a =>
+  Functor render =>
+  (a -> String) ->
+  (Maybe a -> Formlet.Form { readonly :: Boolean | config } render m state result) ->
+  Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (radioGroup :: Render render | renders)) m (State state a) result
+enumRadioGroup display form =
+  radioGroup
+    { display
+    , options: Formlet.Ocelot.Enum.enumOptions
+    }
+    form
+
+-- | A `radio` Form where all option values are filled in with the constructors
+-- | of a `Generic` enum sum type.
+genericRadioGroup ::
+  forall config options render renders result m a rep state.
+  Applicative m =>
+  Eq a =>
+  Functor render =>
+  Generic a rep =>
+  Formlet.Ocelot.Enum.GenericEnumOptions a rep =>
+  (a -> String) ->
+  (Maybe a -> Formlet.Form { readonly :: Boolean | config } render m state result) ->
+  Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (radioGroup :: Render render | renders)) m (State state a) result
+genericRadioGroup display form =
+  radioGroup
+    { display
+    , options: Formlet.Ocelot.Enum.genericEnumOptions
+    }
+    form
+
+-- | Build a singleton Radio Form given a list of options and a way of
+-- | displaying them.
+radioGroup ::
+  forall config options render renders result m a state.
+  Applicative m =>
+  Eq a =>
+  Functor render =>
+  { display :: a -> String
+  , options :: Array a
+  } ->
+  (Maybe a -> Formlet.Form { readonly :: Boolean | config } render m state result) ->
+  Formlet.Form { readonly :: Boolean | config } (Formlet.Render.Render options (radioGroup :: Render render | renders)) m (State state a) result
+radioGroup { display, options } toForm =
+  Formlet.Form \config ->
+    { render:
+        \({ formState, selection }) ->
+          let
+            (Formlet.Form form) = toForm $ validateSelection selection
+          in
+            Formlet.Render.inj
+              { radioGroup:
+                  Render
+                    { options:
+                        options
+                          <#> \a ->
+                            { label: display a
+                            , onSelect: if config.readonly then pure identity else pure (_ { selection = Just a })
+                            }
+                    , readonly: config.readonly
+                    , render: (form config).render formState # map (map \f -> \old -> old { formState = f old.formState })
+                    , value: map display (validateSelection selection)
+                    }
+              }
+    , validate: \state ->
+        let
+          (Formlet.Form form) = toForm $ validateSelection state.selection
+        in
+          (form config).validate state.formState
+    }
+  where
+  validateSelection :: Maybe a -> Maybe a
+  validateSelection = case _ of
+    Nothing -> Nothing
+    Just a
+      | Data.Array.elem a options -> Just a
+    Just _ -> Nothing

--- a/src/Formlet/Ocelot/RadioGroup/Halogen.purs
+++ b/src/Formlet/Ocelot/RadioGroup/Halogen.purs
@@ -1,0 +1,57 @@
+module Formlet.Ocelot.RadioGroup.Halogen
+  ( render
+  ) where
+
+import CitizenNet.Prelude
+
+import Data.Array as Data.Array
+import Foreign.Object as Foreign.Object
+import Formlet.Ocelot.RadioGroup as Formlet.Ocelot.RadioGroup
+import Halogen as Halogen
+import Halogen.HTML as Halogen.HTML
+import Halogen.HTML.Events as Halogen.HTML.Events
+import Halogen.HTML.Properties as Halogen.HTML.Properties
+import Ocelot.Block.Radio as Ocelot.Block.Radio
+import Ocelot.HTML.Properties as Ocelot.HTML.Properties
+
+render ::
+  forall action config m render slots.
+  (render action -> Halogen.ComponentHTML action slots m) ->
+  { key :: String } ->
+  { readonly :: Boolean | config } ->
+  Formlet.Ocelot.RadioGroup.Render render action ->
+  Array (Halogen.ComponentHTML action slots m)
+render renderElement { key } { readonly } (Formlet.Ocelot.RadioGroup.Render render') =
+  [ Halogen.HTML.div
+      [ Ocelot.HTML.Properties.css "flex flex-col" ]
+      ( ( render'.options # Data.Array.mapWithIndex \index ({ label, onSelect }) ->
+            Ocelot.Block.Radio.radio
+              [ Ocelot.HTML.Properties.style $ Foreign.Object.fromHomogeneous
+                  { "order": show index
+                  }
+              ]
+              [ Halogen.HTML.Events.onClick \_ -> onSelect
+              , Halogen.HTML.Properties.checked (render'.value == Just label)
+              , Halogen.HTML.Properties.disabled (readonly || render'.readonly)
+              , Halogen.HTML.Properties.name key
+              ]
+              [ Halogen.HTML.text label ]
+        )
+          <>
+            ( case maybeIndex of
+                Nothing -> []
+                Just index ->
+                  [ Halogen.HTML.div
+                      [ Ocelot.HTML.Properties.style $ Foreign.Object.fromHomogeneous
+                          { "order": show index
+                          }
+                      ]
+                      [ renderElement render'.render ]
+                  ]
+            )
+
+      )
+  ]
+  where
+  maybeIndex :: Maybe Int
+  maybeIndex = Data.Array.findIndex (\x -> Just x.label == render'.value) render'.options

--- a/src/Formlet/Ocelot/Render.purs
+++ b/src/Formlet/Ocelot/Render.purs
@@ -22,6 +22,7 @@ import Formlet.Ocelot.DateTime as Formlet.Ocelot.DateTime
 import Formlet.Ocelot.Dropdown as Formlet.Ocelot.Dropdown
 import Formlet.Ocelot.File as Formlet.Ocelot.File
 import Formlet.Ocelot.Radio as Formlet.Ocelot.Radio
+import Formlet.Ocelot.RadioGroup as Formlet.Ocelot.RadioGroup
 import Formlet.Ocelot.Sequence as Formlet.Ocelot.Sequence
 import Formlet.Ocelot.Table as Formlet.Ocelot.Table
 import Formlet.Ocelot.TabularSelect as Formlet.Ocelot.TabularSelect
@@ -69,6 +70,7 @@ type Renders options renders =
   , dropdown :: Formlet.Ocelot.Dropdown.Render
   , file :: Formlet.Ocelot.File.Render
   , radio :: Formlet.Ocelot.Radio.Render
+  , radioGroup :: Formlet.Ocelot.RadioGroup.Render (Forest options renders)
   , sequence :: Formlet.Ocelot.Sequence.Render (Forest options renders)
   , table :: Formlet.Ocelot.Table.Render (Forest options renders)
   , tabularSelect :: Formlet.Ocelot.TabularSelect.Render

--- a/src/Formlet/Ocelot/Render/Halogen.purs
+++ b/src/Formlet/Ocelot/Render/Halogen.purs
@@ -15,6 +15,7 @@ import Formlet.Ocelot.DateTime.Halogen as Formlet.Ocelot.DateTime.Halogen
 import Formlet.Ocelot.Dropdown.Halogen as Formlet.Ocelot.Dropdown.Halogen
 import Formlet.Ocelot.File.Halogen as Formlet.Ocelot.File.Halogen
 import Formlet.Ocelot.Radio.Halogen as Formlet.Ocelot.Radio.Halogen
+import Formlet.Ocelot.RadioGroup.Halogen as Formlet.Ocelot.RadioGroup.Halogen
 import Formlet.Ocelot.Render as Formlet.Ocelot.Render
 import Formlet.Ocelot.Sequence.Halogen as Formlet.Ocelot.Sequence.Halogen
 import Formlet.Ocelot.Table.Halogen as Formlet.Ocelot.Table.Halogen
@@ -75,6 +76,12 @@ render renderOtherOptions renderOthers config' =
       , dropdown: Formlet.Ocelot.Dropdown.Halogen.render config
       , file: Formlet.Ocelot.File.Halogen.render config
       , radio: Formlet.Ocelot.Radio.Halogen.render { key } config
+      , radioGroup: Formlet.Ocelot.RadioGroup.Halogen.render
+          ( render renderOtherOptions renderOthers config
+              <<< Formlet.Ocelot.Render.mapKey (key <> _)
+          )
+          { key }
+          config
       , sequence:
           Formlet.Ocelot.Sequence.Halogen.render
             ( \sectionKey _ ->
@@ -84,7 +91,7 @@ render renderOtherOptions renderOthers config' =
             config
       , table:
           Formlet.Ocelot.Table.Halogen.render
-            ( \{ column, row } ->
+            ( \({ column, row }) ->
                 render renderOtherOptions renderOthers config
                   <<< Formlet.Ocelot.Render.mapKey (_ <> "-" <> row <> "-" <> column)
             )


### PR DESCRIPTION
## What does this pull request do?

Add `Formlet.Ocelot.RadioGroup` which renders an embedded subform right underneath the selected radio (using [flex `order`](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flexible_box_layout/Ordering_flex_items)).

## How should this be manually tested?

Tested in Wildcat.