### PR TITLE
API-4006 Prevent Toggling When User Clicks on the Field Title

### DIFF
--- a/src/Formlet/Ocelot/Toggle/Halogen.purs
+++ b/src/Formlet/Ocelot/Toggle/Halogen.purs
@@ -36,6 +36,5 @@ render { key } { readonly } (Formlet.Ocelot.Toggle.Render render') = case render
       [ Halogen.HTML.Properties.checked render'.value
       , Halogen.HTML.Properties.disabled (readonly || render'.readonly)
       , Halogen.HTML.Events.onChecked render'.onChange
-      , Halogen.HTML.Properties.id key
       , Halogen.HTML.Properties.name key
       ]


### PR DESCRIPTION
## What does this pull request do?

We have `for` that links the same `id` on the form field label/title so when user clicks on the title, the toggle switches. Per Product request, we need to update this behavior to be consistent with the rest of the site so we remove the `id` here to de-link the title and the toggle input.

## How should this be manually tested?

Test in Wildcat with this branch