### PR TITLE
API-4047 Fix Radio and Radio Group in Tabbed Forms

### DIFF
--- a/src/Formlet/Ocelot/Radio/Halogen.purs
+++ b/src/Formlet/Ocelot/Radio/Halogen.purs
@@ -13,17 +13,15 @@ import Ocelot.Block.Radio as Ocelot.Block.Radio
 
 render ::
   forall slots m config action.
-  { key :: String } ->
   { readonly :: Boolean | config } ->
   Formlet.Ocelot.Radio.Render action ->
   Array (Halogen.ComponentHTML action slots m)
-render { key } { readonly } (Formlet.Ocelot.Radio.Render render') =
+render { readonly } (Formlet.Ocelot.Radio.Render render') =
   render'.options
     # map \({ label, onSelect }) ->
         Ocelot.Block.Radio.radio_
           [ Halogen.HTML.Events.onClick \_ -> onSelect
           , Halogen.HTML.Properties.checked (render'.value == Just label)
           , Halogen.HTML.Properties.disabled (readonly || render'.readonly)
-          , Halogen.HTML.Properties.name key
           ]
           [ Halogen.HTML.text label ]

--- a/src/Formlet/Ocelot/RadioGroup/Halogen.purs
+++ b/src/Formlet/Ocelot/RadioGroup/Halogen.purs
@@ -17,11 +17,10 @@ import Ocelot.HTML.Properties as Ocelot.HTML.Properties
 render ::
   forall action config m render slots.
   (render action -> Halogen.ComponentHTML action slots m) ->
-  { key :: String } ->
   { readonly :: Boolean | config } ->
   Formlet.Ocelot.RadioGroup.Render render action ->
   Array (Halogen.ComponentHTML action slots m)
-render renderElement { key } { readonly } (Formlet.Ocelot.RadioGroup.Render render') =
+render renderElement { readonly } (Formlet.Ocelot.RadioGroup.Render render') =
   [ Halogen.HTML.div
       [ Ocelot.HTML.Properties.css "flex flex-col" ]
       ( ( render'.options # Data.Array.mapWithIndex \index ({ label, onSelect }) ->
@@ -33,7 +32,6 @@ render renderElement { key } { readonly } (Formlet.Ocelot.RadioGroup.Render rend
               [ Halogen.HTML.Events.onClick \_ -> onSelect
               , Halogen.HTML.Properties.checked (render'.value == Just label)
               , Halogen.HTML.Properties.disabled (readonly || render'.readonly)
-              , Halogen.HTML.Properties.name key
               ]
               [ Halogen.HTML.text label ]
         )

--- a/src/Formlet/Ocelot/Render/Halogen.purs
+++ b/src/Formlet/Ocelot/Render/Halogen.purs
@@ -75,12 +75,11 @@ render renderOtherOptions renderOthers config' =
       , dateTime: Formlet.Ocelot.DateTime.Halogen.render config
       , dropdown: Formlet.Ocelot.Dropdown.Halogen.render config
       , file: Formlet.Ocelot.File.Halogen.render config
-      , radio: Formlet.Ocelot.Radio.Halogen.render { key } config
+      , radio: Formlet.Ocelot.Radio.Halogen.render config
       , radioGroup: Formlet.Ocelot.RadioGroup.Halogen.render
           ( render renderOtherOptions renderOthers config
               <<< Formlet.Ocelot.Render.mapKey (key <> _)
           )
-          { key }
           config
       , sequence:
           Formlet.Ocelot.Sequence.Halogen.render


### PR DESCRIPTION
## What does this pull request do?

`name` attribute on radio `input` is supposed to be unique globally throughout a page otherwise one would deselect the other under the same `name`. But it's common in a page with multiple tabs of the same form to share the same `name` in each tab. Managing unique `name`s is a pain. Removing `name` attribute from `Radio` and `RadioGroup` components altogether to prevent this from happening.